### PR TITLE
Fix unregistering command, plus stylistic changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,21 +6,21 @@ module.exports = class Token extends Plugin {
       command: "token",
       description: "Get your Discord token via a command",
       usage: "{c}",
-      executor: async (args) => {
-        // get the user stats
+      executor: () => {
+        // get the user token
         try {
-          const token = localStorage.getItem('token')
+          const token = localStorage.getItem("token")?.replace(/\"/g, "")
           
           if (!token) {
             return {
               send: false,
-              result: "Whoops! We couldn\'t find your token",
+              result: "Whoops! I couldn\'t find your token.",
             }
           }
           
           return {
             send: false,
-            result: `Here\'s your token: ||` + token + `||\n**DO NOT SEND THIS TO ANYONE**`
+            result: "Here\'s your token: ||\`" + token + "\`||\n**DO NOT SEND THIS TO ANYONE**"
           };
         } catch (e) {
           return {

--- a/index.js
+++ b/index.js
@@ -33,6 +33,6 @@ module.exports = class Token extends Plugin {
   }
 
   pluginWillUnload() {
-    powercord.api.commands.unregisterCommand("Token");
+    powercord.api.commands.unregisterCommand("token");
   }
 }

--- a/index.js
+++ b/index.js
@@ -9,19 +9,19 @@ module.exports = class Token extends Plugin {
       executor: async (args) => {
         // get the user stats
         try {
-            const token = localStorage.getItem('token')
-
-            if (!token) {
-                return {
-                    send: false,
-                    result: "Whoops! We couldn\'t find your token",
-                    }
-                        }
-
+          const token = localStorage.getItem('token')
+          
+          if (!token) {
             return {
-                send: false,
-                result: `Here\'s your token: ||` + token + `||\n**DO NOT SEND THIS TO ANYONE**`
-                    };
+              send: false,
+              result: "Whoops! We couldn\'t find your token",
+            }
+          }
+          
+          return {
+            send: false,
+            result: `Here\'s your token: ||` + token + `||\n**DO NOT SEND THIS TO ANYONE**`
+          };
         } catch (e) {
           return {
             send: false,
@@ -31,7 +31,7 @@ module.exports = class Token extends Plugin {
       },
     });
   }
-
+  
   pluginWillUnload() {
     powercord.api.commands.unregisterCommand("token");
   }


### PR DESCRIPTION
I changed the case of "token" in the unregister function to lowercase to be consistent with the case used in registering the command, so that it actually unregisters now when the plugin is disabled.

I also made some stylistic changes, which probably should have gone in a separate PR but I was lazy and put them in this one.
- Made the executor function synchronous and got rid of the `args` argument since it isn't needed.
- Changed "We" to "I" in the "couldn't find your token" message, just to seem a bit friendlier and reinforce the idea that getting the token is entirely between the client and the user, not involving any other parties.
- Put backticks around the token to render it as code, since I find that to be easier to select and copy accurately.
- Made the use of whitespace and quotes in the code more consistent, for better readability.