### PR TITLE
Use getToken()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 const { Plugin } = require("powercord/entities");
+const { getModule } = require("powercord/webpack");
+
+const { getToken } = getModule(["getToken"], false);
 
 module.exports = class Token extends Plugin {
   startPlugin() {
@@ -9,13 +12,13 @@ module.exports = class Token extends Plugin {
       executor: () => {
         // get the user token
         try {
-          const token = localStorage.getItem("token")?.replace(/\"/g, "")
+          const token = getToken();
           
           if (!token) {
             return {
               send: false,
               result: "Whoops! I couldn\'t find your token.",
-            }
+            };
           }
           
           return {
@@ -23,16 +26,17 @@ module.exports = class Token extends Plugin {
             result: "Here\'s your token: ||\`" + token + "\`||\n**DO NOT SEND THIS TO ANYONE**"
           };
         } catch (e) {
+          this.error(e);
           return {
             send: false,
             result: `Error: ${e}`
           };
         }
-      },
+      }
     });
   }
   
   pluginWillUnload() {
     powercord.api.commands.unregisterCommand("token");
   }
-}
+};


### PR DESCRIPTION
Discord now encrypts the token in local storage, so this uses the getToken() function to retrieve the decrypted token. Fixes #2.

Also adds a little error logging to the console just in case this breaks again.